### PR TITLE
Allow use of NS File Cabinet root directory

### DIFF
--- a/src/netsuite/NSClient.java
+++ b/src/netsuite/NSClient.java
@@ -215,6 +215,15 @@ public class NSClient	{
     }
 
     public String searchFolder(String folder, String parentFolderId) throws RemoteException {
+
+        SearchStringField nameField = new SearchStringField();
+        nameField.setSearchValue(folder);
+        nameField.setOperator(SearchStringFieldOperator.is);
+
+        //search for parent, if no parent, then it is file cabinet root directory
+        if (parentFolderId == null || parentFolderId.isEmpty()) {
+            parentFolderId = "@NONE@";
+        }
         RecordRef parentFolderRef = new RecordRef();
         parentFolderRef.setInternalId(parentFolderId);
 
@@ -226,9 +235,6 @@ public class NSClient	{
         smsf.setOperator(SearchMultiSelectFieldOperator.anyOf);
 
         FolderSearchBasic subDirectoryFolderSearch = new FolderSearchBasic();
-        SearchStringField nameField = new SearchStringField();
-        nameField.setSearchValue(folder);
-        nameField.setOperator(SearchStringFieldOperator.is);
         subDirectoryFolderSearch.setName(nameField);
         subDirectoryFolderSearch.setParent(smsf);
 

--- a/src/projectsettings/ProjectSettingsController.java
+++ b/src/projectsettings/ProjectSettingsController.java
@@ -42,9 +42,7 @@ public class ProjectSettingsController {
     }
 
     public void setNsRootFolder(String nsRootFolder) {
-        if (nsRootFolder != null && !nsRootFolder.isEmpty()) {
-            propertiesComponent.setValue(PROJECT_SETTING_NETSUITE_ROOT_FOLDER, nsRootFolder);
-        }
+        propertiesComponent.setValue(PROJECT_SETTING_NETSUITE_ROOT_FOLDER, nsRootFolder);
     }
 
     public String getNsAccount() {
@@ -102,7 +100,6 @@ public class ProjectSettingsController {
 
     public boolean hasAllProjectSettings() {
         return (getNsEmail()       != null && !getNsEmail().isEmpty()      &&
-                getNsRootFolder()  != null && !getNsRootFolder().isEmpty() &&
                 getNsAccount()     != null && !getNsAccount().isEmpty()    &&
                 getNsEnvironment() != null && !getNsEnvironment().isEmpty());
     }

--- a/src/ui/FolderSelectionUI.java
+++ b/src/ui/FolderSelectionUI.java
@@ -154,7 +154,7 @@ public class FolderSelectionUI extends JDialog {
             }
             if (folderName.equals(FILE_CABINET_ROOT)) {
                 Integer confirmed = JOptionPane.showConfirmDialog(null, "You are setting the directory to " + folderName + ".\nThis is the root folder of NetSuite. Please be sure this is what you want to do as it is not recommended. Are you sure?",  "WARNING", JOptionPane.CANCEL_OPTION);
-                if (confirmed == 1){
+                if (confirmed == 2){ //CANCEL
                     return;
                 }
                 nsRootFolderId = FILE_CABINET_ROOT_INTERNAL_ID;

--- a/src/ui/FolderSelectionUI.java
+++ b/src/ui/FolderSelectionUI.java
@@ -153,7 +153,7 @@ public class FolderSelectionUI extends JDialog {
                 return;
             }
             if (folderName.equals(FILE_CABINET_ROOT)) {
-                int confirmed = JOptionPane.showConfirmDialog(null, "You are setting the directory to " + folderName + ".\nThis is the root folder of NetSuite. Please be sure this is what you want to do as it is not recommended. Are you sure?",  "WARNING", JOptionPane.CANCEL_OPTION);
+                int confirmed = JOptionPane.showConfirmDialog(null, "You are setting the directory to " + folderName + ". This is the root folder of the NetSuite File Cabinet. \nThis is not recommended. Are you sure?",  "WARNING", JOptionPane.CANCEL_OPTION);
                 if (confirmed != 0) {
                     return;
                 }

--- a/src/ui/FolderSelectionUI.java
+++ b/src/ui/FolderSelectionUI.java
@@ -33,6 +33,7 @@ public class FolderSelectionUI extends JDialog {
 
     final private String SUITESCRIPTS_FOLDER_INTERNAL_ID = "-15";
     final private String SUITEBUNDLES_FOLDER_INTERNAL_ID = "-16";
+    final private String FILE_CABINET_ROOT_INTERNAL_ID = "";
     final private String FILE_CABINET_ROOT               = "File Cabinet";
     final private String FILE_CABINET_SUITESCRIPTS       = "SuiteScripts";
     final private String FILE_CABINET_SUITEBUNDLES       = "SuiteBundles";
@@ -107,6 +108,9 @@ public class FolderSelectionUI extends JDialog {
         SearchResult folderResults = null;
 
         try {
+            if (parentFolderId == FILE_CABINET_ROOT_INTERNAL_ID){
+                parentFolderId = null;
+            }
             folderResults = this.nsClient.getSubFolders(parentFolderId);
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(null, "Error getting Sub Folders",  "ERROR", JOptionPane.ERROR_MESSAGE);
@@ -144,20 +148,24 @@ public class FolderSelectionUI extends JDialog {
             FileTreeFolder folder = (FileTreeFolder)node.getUserObject();
             String folderName = folder.getFolder().getName();
 
-            if (folderName != null) {
-                if (folderName.equals(FILE_CABINET_SUITESCRIPTS) ||
-                        folderName.equals(FILE_CABINET_SUITEBUNDLES) ||
-                        folderName.equals(FILE_CABINET_ROOT)) {
-                    JOptionPane.showMessageDialog(null, "Cannot set directory to " + folderName + ".\nPlease select another directory.",  "ERROR", JOptionPane.ERROR_MESSAGE);
+            if (folderName == null) {
+                JOptionPane.showMessageDialog(null, "Folder must be selected or Folder ID specified",  "ERROR", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+            if (folderName.equals(FILE_CABINET_ROOT)) {
+                Integer confirmed = JOptionPane.showConfirmDialog(null, "You are setting the directory to " + folderName + ".\nThis is the root folder of NetSuite. Please be sure this is what you want to do as it is not recommended. Are you sure?",  "WARNING", JOptionPane.CANCEL_OPTION);
+                if (confirmed == 1){
                     return;
                 }
+                nsRootFolderId = FILE_CABINET_ROOT_INTERNAL_ID;
+            } else {
                 nsRootFolderId = folder.getFolder().getInternalId();
             }
         } else {
             nsRootFolderId = rootFolderIdTextField.getText().trim();
         }
 
-        if (nsRootFolderId.isEmpty()) {
+        if (nsRootFolderId == null) {
             JOptionPane.showMessageDialog(null, "Folder must be selected or Folder ID specified",  "ERROR", JOptionPane.ERROR_MESSAGE);
             return;
         }

--- a/src/ui/FolderSelectionUI.java
+++ b/src/ui/FolderSelectionUI.java
@@ -154,7 +154,7 @@ public class FolderSelectionUI extends JDialog {
             }
             if (folderName.equals(FILE_CABINET_ROOT)) {
                 int confirmed = JOptionPane.showConfirmDialog(null, "You are setting the directory to " + folderName + ".\nThis is the root folder of NetSuite. Please be sure this is what you want to do as it is not recommended. Are you sure?",  "WARNING", JOptionPane.CANCEL_OPTION);
-                if (confirmed == 2){ //CANCEL
+                if (confirmed != 0) {
                     return;
                 }
                 nsRootFolderId = FILE_CABINET_ROOT_INTERNAL_ID;

--- a/src/ui/FolderSelectionUI.java
+++ b/src/ui/FolderSelectionUI.java
@@ -153,7 +153,7 @@ public class FolderSelectionUI extends JDialog {
                 return;
             }
             if (folderName.equals(FILE_CABINET_ROOT)) {
-                Integer confirmed = JOptionPane.showConfirmDialog(null, "You are setting the directory to " + folderName + ".\nThis is the root folder of NetSuite. Please be sure this is what you want to do as it is not recommended. Are you sure?",  "WARNING", JOptionPane.CANCEL_OPTION);
+                int confirmed = JOptionPane.showConfirmDialog(null, "You are setting the directory to " + folderName + ".\nThis is the root folder of NetSuite. Please be sure this is what you want to do as it is not recommended. Are you sure?",  "WARNING", JOptionPane.CANCEL_OPTION);
                 if (confirmed == 2){ //CANCEL
                     return;
                 }


### PR DESCRIPTION
This allows users to specify NetSuite's File Cabinet as the root directory for their project. This is helpful if you need to upload/compare to more than just a single NS folder (SuiteScripts + SuiteBundles, for example) within a single project.

It also removes restriction on selecting SuiteScripts and SuiteBundles folder in the Folder Selection UI.